### PR TITLE
Added a very simple error message when the Login endpoint fails.

### DIFF
--- a/src/components/authentication/Authenticate.tsx
+++ b/src/components/authentication/Authenticate.tsx
@@ -75,6 +75,7 @@ export const Authenticate: React.FC<Props> = ({ setToken, setAddress }) => {
   });
 
   const [authMode, setAuthMode] = useState<authModeEnum>(authModeEnum.singin);
+  const [error, setError] = useState<string | undefined>(undefined);
 
   const changeAuthMode = () => {
     setAuthMode(
@@ -122,6 +123,8 @@ export const Authenticate: React.FC<Props> = ({ setToken, setAddress }) => {
     if (!_.isNil(res)) {
       setToken(res.token);
       fetchAndSetAddress(res.token);
+    } else {
+      setError("Incorrect username or password");
     }
   };
 
@@ -142,6 +145,7 @@ export const Authenticate: React.FC<Props> = ({ setToken, setAddress }) => {
           alt="Whitflag Logo"
         />
       </div>
+      {error && <Text type="danger">{error}</Text>}
       {authMode === authModeEnum.singin ? (
         <React.Fragment>
           <Form


### PR DESCRIPTION
In the event that the login endpoint on Fennel Labs' API is sent a bad username/password combination, the API returns a 400 error with a notification that login couldn't be completed with the given credentials. Currently, the app silently fails if it encounters this behavior. This patch adds a very simple error popup letting the user know that their login failed in the event that the return from the loginEndpoint.directPost call is null.